### PR TITLE
Add External Link to Title

### DIFF
--- a/src/assets/external_link.svg
+++ b/src/assets/external_link.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 -256 1850 1850"
+   id="svg3025"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   width="100%"
+   height="100%"
+   sodipodi:docname="external_link_font_awesome.svg">
+  <metadata
+     id="metadata3035">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3033" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview3031"
+     showgrid="false"
+     inkscape:zoom="0.13169643"
+     inkscape:cx="896"
+     inkscape:cy="896"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3025" />
+  <g
+     transform="matrix(1,0,0,-1,30.372881,1426.9492)"
+     id="g3027">
+    <path
+       d="M 1408,608 V 288 Q 1408,169 1323.5,84.5 1239,0 1120,0 H 288 Q 169,0 84.5,84.5 0,169 0,288 v 832 Q 0,1239 84.5,1323.5 169,1408 288,1408 h 704 q 14,0 23,-9 9,-9 9,-23 v -64 q 0,-14 -9,-23 -9,-9 -23,-9 H 288 q -66,0 -113,-47 -47,-47 -47,-113 V 288 q 0,-66 47,-113 47,-47 113,-47 h 832 q 66,0 113,47 47,47 47,113 v 320 q 0,14 9,23 9,9 23,9 h 64 q 14,0 23,-9 9,-9 9,-23 z m 384,864 V 960 q 0,-26 -19,-45 -19,-19 -45,-19 -26,0 -45,19 L 1507,1091 855,439 q -10,-10 -23,-10 -13,0 -23,10 L 695,553 q -10,10 -10,23 0,13 10,23 l 652,652 -176,176 q -19,19 -19,45 0,26 19,45 19,19 45,19 h 512 q 26,0 45,-19 19,-19 19,-45 z"
+       id="path3029"
+       inkscape:connector-curvature="0"
+       style="fill:#454545;" />
+  </g>
+</svg>

--- a/src/components/controls/InfoPanelControl.tsx
+++ b/src/components/controls/InfoPanelControl.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { useMap } from 'react-leaflet'
 
 import { Stakeholder } from 'types'
+import ExternalLinkSvg from 'assets/external_link.svg'
+
 interface InfoPanelControlProps {
   stakeholder: Stakeholder | null
   onClose: () => void
@@ -45,9 +47,10 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({ stakeholder, onClos
                 href={stakeholder.website}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-gradient-to-r from-black-900 to-black-600 bg-[length:0_0.1em] bg-[position:0_100%] bg-no-repeat text-2xl font-bold !text-black-700 transition-all duration-100 hover:bg-[length:100%_0.1em]"
+                className="inline-flex items-center bg-gradient-to-r from-black-900 to-black-600 bg-[length:0_0.1em] bg-[position:0_100%] bg-no-repeat text-2xl font-bold !text-black-700 transition-all duration-100 hover:bg-[length:100%_0.1em]"
               >
-                {stakeholder.name}
+                <span>{stakeholder.name}</span>
+                <img src={ExternalLinkSvg} alt="link" className="ml-2 h-5" />
               </a>
             </div>
             {driveFileId && <img className="mx-auto mb-5 w-80" src={`https://drive.google.com/uc?id=${driveFileId}`} alt={`${stakeholder.name} logo`} />}

--- a/src/components/controls/InfoPanelControl.tsx
+++ b/src/components/controls/InfoPanelControl.tsx
@@ -43,15 +43,19 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({ stakeholder, onClos
 
           <div key={stakeholder.contact} className="px-6 py-10">
             <div className="mb-4 ">
-              <a
-                href={stakeholder.website}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center bg-gradient-to-r from-black-900 to-black-600 bg-[length:0_0.1em] bg-[position:0_100%] bg-no-repeat text-2xl font-bold !text-black-700 transition-all duration-100 hover:bg-[length:100%_0.1em]"
-              >
-                <span>{stakeholder.name}</span>
-                <img src={ExternalLinkSvg} alt="link" className="ml-2 h-5" />
-              </a>
+              <span className="inline">
+                <a
+                  href={stakeholder.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-gradient-to-r from-black-900 to-black-500 bg-[length:0_0.1em] bg-[position:0_100%] bg-no-repeat text-2xl font-bold !text-black-700 transition-all duration-150 hover:bg-[length:100%_0.1em]"
+                >
+                  {stakeholder.name}
+                </a>
+                <span className="inline-block align-text-bottom">
+                  <img src={ExternalLinkSvg} alt="link" className="ml-2 h-5" />
+                </span>
+              </span>
             </div>
             {driveFileId && <img className="mx-auto mb-5 w-80" src={`https://drive.google.com/uc?id=${driveFileId}`} alt={`${stakeholder.name} logo`} />}
             <div className="mb-6 text-sm text-black-800">{stakeholder.description}</div>


### PR DESCRIPTION
Currently, clicking the title navigates the user to the stakeholders page. However, this isn't really evident without hovering over the title.

This PR adds an SVG external link image right next to the title to make this more clear.