### PR TITLE
Adjustments

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -25,7 +25,7 @@ const Map: React.FC<MapProps> = ({ apiKey, stakeholders }) => {
   const markersLayer = useRef(null)
 
   return (
-    <MapContainer className="h-full w-full" center={[20, 0]} zoom={3} minZoom={3} scrollWheelZoom={true} zoomControl={false} maxBounds={maxBounds}>
+    <MapContainer className="h-full w-full" center={[20, 0]} zoom={2} minZoom={2} scrollWheelZoom={true} zoomControl={false} maxBounds={maxBounds}>
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url={`https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png?api_key=${apiKey}`}

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -42,7 +42,7 @@ const Map: React.FC<MapProps> = ({ apiKey, stakeholders }) => {
 
       <SearchControl layerRef={markersLayer} />
       <TagControl stakeholders={stakeholders} layerRef={markersLayer} />
-      <ZoomControl zoomLevel={3} />
+      <ZoomControl zoomLevel={2} />
     </MapContainer>
   )
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -7,7 +7,7 @@ import InfoPanelControl from 'components/controls/InfoPanelControl'
 import ZoomControl from 'components/controls/ZoomControl'
 import TagControl from './controls/TagControl'
 import LegendControl from './controls/LegendControl'
-import { LatLngBoundsLiteral} from 'leaflet'
+import { LatLngBoundsLiteral } from 'leaflet'
 
 interface MapProps {
   apiKey: string
@@ -25,7 +25,7 @@ const Map: React.FC<MapProps> = ({ apiKey, stakeholders }) => {
   const markersLayer = useRef(null)
 
   return (
-    <MapContainer className="w-full h-full" center={[20, 0]} zoom={3} minZoom={3} scrollWheelZoom={true} zoomControl={false} maxBounds={maxBounds}>
+    <MapContainer className="h-full w-full" center={[20, 0]} zoom={3} minZoom={3} scrollWheelZoom={true} zoomControl={false} maxBounds={maxBounds}>
       <TileLayer
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url={`https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png?api_key=${apiKey}`}
@@ -37,10 +37,8 @@ const Map: React.FC<MapProps> = ({ apiKey, stakeholders }) => {
         ref={markersLayer}
         showLocationsServedMarkers={false}
       />
-      <div className="hidden md:block">
-        <LegendControl selectedStakeholder={selectedStakeholder} />
-      </div>
-      <InfoPanelControl stakeholder={selectedStakeholder}  onClose={() => setSelectedStakeholder(null)}/>
+      <LegendControl selectedStakeholder={selectedStakeholder} />
+      <InfoPanelControl stakeholder={selectedStakeholder} onClose={() => setSelectedStakeholder(null)} />
 
       <SearchControl layerRef={markersLayer} />
       <TagControl stakeholders={stakeholders} layerRef={markersLayer} />

--- a/src/components/controls/InfoPanelControl.tsx
+++ b/src/components/controls/InfoPanelControl.tsx
@@ -41,7 +41,7 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({ stakeholder, onClos
     <div
       key={'overlay'}
       className={`${
-        stakeholder ? 'w-[100%] xl:w-[400px]' : 'w-0'
+        stakeholder ? 'w-[100%] md:w-[400px]' : 'w-0'
       } duration-400 fixed left-0 z-[1000] box-border h-screen cursor-default overflow-y-auto bg-tint-02 bg-opacity-80 !font-proxima-nova shadow-md transition-all duration-100`}
       onMouseEnter={disableZoom}
       onMouseLeave={enableZoom}

--- a/src/components/controls/InfoPanelControl.tsx
+++ b/src/components/controls/InfoPanelControl.tsx
@@ -118,11 +118,6 @@ const InfoPanelControl: React.FC<InfoPanelControlProps> = ({ stakeholder, onClos
                   </div>
                 </div>
               )}
-              <div className="mb-4 md:hidden">
-                <div className="ml-2 mt-2">
-                  <LegendControl selectedStakeholder={stakeholder} />
-                </div>
-              </div>
             </div>
           </div>
         </>

--- a/src/components/controls/LegendControl.tsx
+++ b/src/components/controls/LegendControl.tsx
@@ -4,21 +4,25 @@ interface LegendControlProps {
   selectedStakeholder: any
 }
 
-const LegendControl: React.FC<LegendControlProps> = ({ selectedStakeholder}) => {
+const LegendControl: React.FC<LegendControlProps> = ({ selectedStakeholder }) => {
+  const legend = (
+    <div className="absolute bottom-3 right-3 z-[1000] m-3 block rounded-md bg-tint-02 bg-opacity-70 p-3">
+      <div className="mt-1 flex items-center">
+        <img src={'marker.svg'} alt="Marker 1" className="mr-1 h-8 w-8" />
+        <span className="font-proxima-nova text-sm font-semibold text-shade-01">Headquarters/Registration</span>
+      </div>
+      <div className="mt-1 flex items-center">
+        <img src={'selected-marker.svg'} alt="Selected Marker" className="mr-1 h-8 w-8" />
+        <span className="font-proxima-nova text-sm font-semibold text-shade-01">Selected</span>
+      </div>
+    </div>
+  )
+
+  // Hide legend only on a smaller screen with stakeholder selected
   return (
     <>
-      {selectedStakeholder && (
-        <div className={"bg-tint-02 md:absolute md:bottom-3 md:right-3 z-[1000] md:m-3 rounded-md bg-opacity-70 p-3 "}>
-          <div className="mt-1 flex items-center">
-            <img src={'marker.svg'} alt="Marker 1" className="mr-1 h-8 w-8" />
-            <span className="font-proxima-nova text-shade-01 text-sm font-semibold">Headquarters/Registration</span>
-          </div>
-          <div className="mt-1 flex items-center">
-            <img src={'selected-marker.svg'} alt="Selected Marker" className="mr-1 h-8 w-8" />
-            <span className="font-proxima-nova text-shade-01 text-sm font-semibold">Selected</span>
-          </div>
-        </div>
-      )}
+      {!selectedStakeholder && legend}
+      {selectedStakeholder && <div className="hidden md:block">{legend}</div>}
     </>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 import colors from 'tailwindcss/colors'
 
 /** Extended colors/fonts conforming to https://www.hsph.harvard.edu/communications-guide/ */
+/** Screen sizes based on https://www.hsph.harvard.edu/atrocity-prevention-lab/collaborators/ */
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -57,6 +58,9 @@ export default {
     fontFamily: {
       merriweather: ['Merriweather', 'sans-serif'],
       'proxima-nova': ['proxima-nova', 'sans-serif'],
+    },
+    screens: {
+      md: '720px',
     },
   },
   plugins: [],


### PR DESCRIPTION
Addresses #71 and #72.

Changes
- Set "md" breakpoint to be 720px. Currently, the wordpress site renders 1020px wide on 1080p and 1440p screens.
- Sets the default zoom and "reset" zoom to 2 instead of 3. On 1020x600, this now shows the entire world view
- Adjusts legend to render always, excluding the one scenario on small screens + stakeholder selected (where the info panel occupies the whole screen)